### PR TITLE
Adds missing build dependency

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -6,7 +6,8 @@
     "magician": "~0.1.1",
     "async": "~0.1.22",
     "mustache": "~0.7.0",
-    "yamljs": "~0.1.4"
+    "yamljs": "~0.1.4",
+    "q": "~1.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Now can run build scripts by just running:

```
cd build
npm install
cd ..
```

Previously you had to also do:

```
npm install q
```
