### PR TITLE
Updated automated PhoneGap Build scripts

### DIFF
--- a/phonegap/common-with-winphone/config.xml
+++ b/phonegap/common-with-winphone/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns="http://www.w3.org/ns/widgets"
 	    xmlns:gap="http://phonegap.com/ns/1.0"
 	    id="com.propertycross.[ID]"
-	    version="1.0.0">
+	    version="[VERSION]">
 
     <name>PropertyCross - [IMPL]</name>
 

--- a/phonegap/common/build.js
+++ b/phonegap/common/build.js
@@ -57,7 +57,7 @@ module.exports = {
     config.copy.configXml.options.process = function(content) {
       var impl = grunt.config.get("pkg.implName");
       grunt.log.oklns("Setting implementation name to "+impl);
-      return content.replace(/\[IMPL\]/g, impl).replace(/\[ID\]/g, grunt.config.get("pkg.abbr"));
+      return content.replace(/\[IMPL\]/g, impl).replace(/\[ID\]/g, grunt.config.get("pkg.abbr")).replace(/\[VERSION\]/g, grunt.config.get("pkg.version"));
     }
 
     if (mutateConfig) {

--- a/phonegap/common/config.xml
+++ b/phonegap/common/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns="http://www.w3.org/ns/widgets"
 	    xmlns:gap="http://phonegap.com/ns/1.0"
 	    id="com.propertycross.[ID]"
-	    version="1.0.0">
+	    version="[VERSION]">
 
     <name>PropertyCross - [IMPL]</name>
 


### PR DESCRIPTION
PhoneGap Builds triggered through grunt previously gave the build version '1.0.0', regardless of the data in the package file.

The pull request causes the build version in the PhoneGap Build `config.xml` file to be populated from the `package.json`.
