### PR TITLE
Automated PhoneGap Builds scripts to support custom email addresses

### DIFF
--- a/phonegap/common/build.js
+++ b/phonegap/common/build.js
@@ -11,7 +11,7 @@ module.exports = {
           archive: "app.zip",
           appId: "<%= pkg.appId %>",
           user: {
-            email: "propertycrossbuilds+<%= pkg.abbr %>@gmail.com",
+            email: "<%= grunt.option('pgb.email') || 'propertycrossbuilds+' + pkg.abbr + '@gmail.com' %>",
             password: "<%= grunt.option('pgb.password') %>"
           },
           download: {


### PR DESCRIPTION
This enables other people in the community to use the build scripts we have provided with their own PhoneGap Build Adobe accounts.
